### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -18,6 +18,10 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show
+    @item = Item.find(params[:id])
+  end
+
   private
 
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
 
   def index
-    @items = Item.order("created_at DESC")
+    @items = Item.order('created_at DESC')
   end
 
   def new

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -18,7 +18,7 @@ class Item < ApplicationRecord
   end
 
   belongs_to :user
-  #has_one :order  
+  # has_one :order
   has_one_attached :image
 
   extend ActiveHash::Associations::ActiveRecordExtensions

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,4 @@
 class User < ApplicationRecord
-  
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
@@ -12,7 +11,6 @@ class User < ApplicationRecord
   validates :first_name_kana, presence: true, format: { with: /\A[ァ-ヶー－]+\z/ }
   validates :birthday, presence: true
 
-   has_many :items
-   #has_many :orders
-   
+  has_many :items
+  # has_many :orders
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -134,11 +134,11 @@
          <div class='item-img-content'>
            <%= image_tag item.image , class: "item-img"  if item.image.attached?%>
 
-           <% if @item.present? %>
+           <%# if @item.present? %>
            <div class='sold-out'>
              <span>Sold Out!!</span>
            </div>
-           <% end %>
+           <%# end %>
 
          </div>
          <div class='item-info'>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -130,15 +130,15 @@
 
        <% @items.each do |item| %>
        <li class='list'>
-         <%#= link_to new_item_path(@item) do %>
+        <%= link_to item_path(item) do %>
          <div class='item-img-content'>
            <%= image_tag item.image , class: "item-img"  if item.image.attached?%>
 
-           <%# if @item.present? %>
+           <% if @item.present? %>
            <div class='sold-out'>
              <span>Sold Out!!</span>
            </div>
-           <%#end %>
+           <% end %>
 
          </div>
          <div class='item-info'>
@@ -153,7 +153,7 @@
              </div>
            </div>
          </div>
-        
+       <%end%>
        </li>
        <% end %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -8,11 +8,11 @@
     </h2>
     <div class="item-img-content">
       <%= image_tag @item.image, class:"item-box-img" if @item.image.attached? %>
-       <% if @item.present?&& user_signed_in? %>
+       <%# if @item.present?&& user_signed_in? %>
       <div class="sold-out">
         <span>Sold Out!!</span>
       </div>
-       <%end%>
+       <%#end%>
     </div>
     <div class="item-price-box">
       <span class="item-price">
@@ -104,7 +104,7 @@
     </a>
   </div>
   <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
   <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,67 +4,67 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
+      <%= image_tag @item.image, class:"item-box-img" if @item.image.attached? %>
+       <% if @item.present?&& user_signed_in? %>
       <div class="sold-out">
         <span>Sold Out!!</span>
       </div>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
+       <%end%>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= @item.price %>円
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.shipping_cost.name %>
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
+    <% if current_user==@item.user&& @item.present? && user_signed_in?%>
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+    <%end%>
 
 
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
+    <% if user_signed_in?&& @item.present? && @item.user!=current_user  %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
+    <%end %>
 
 
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+   
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.description %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.item_statue.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.shipping_cost.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.shipping_date.name %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -23,19 +23,20 @@
       </span>
     </div>
 
-    <% if current_user==@item.user&& @item.present? && user_signed_in?%>
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-    <p class="or-text">or</p>
-    <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
-    <%end%>
+    
+
+    <% if user_signed_in?%>
+      <% if current_user==@item.user%>
+        <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+          <p class="or-text">or</p>
+        <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+      <% else %>
+        <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+      <% end %>
+    <% end %>
 
 
-    <% if user_signed_in?&& @item.present? && @item.user!=current_user  %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%end %>
 
-
-   
 
     <div class="item-explain-box">
       <span><%= @item.description %></span>
@@ -103,9 +104,9 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+  
   <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+ 
 </div>
 
 <%= render "shared/footer" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,6 @@ Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
 
-  resources :items, only: [:new, :create,:index]
+  resources :items, only: [:new, :create,:index,:show]
   
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Item, type: :model do
       it 'Userが紐づいていないと出品できない' do
         @item.user = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("User must exist")
+        expect(@item.errors.full_messages).to include('User must exist')
       end
       it '１枚画像がないと出品できない' do
         @item.image = nil


### PR DESCRIPTION
＃What
　商品詳細表示機能の実装
＃Why
　商品詳細のページを閲覧するため


•	ログイン状態且つ、自身が出品した販売中商品の商品詳細ページへ遷移した動画https://gyazo.com/9954b11ded92d98c3eda1f382e37b147
•	 ログイン状態且つ、自身が出品していない販売中商品の商品詳細ページへ遷移した動画https://gyazo.com/c0e649f80069001f48323d84526f7aef
•	 ログイン状態で、売却済み商品の商品詳細ページへ遷移した動画（現段階で商品購入機能の実装が済んでいる場合）→まだ済んでいません
•	 ログアウト状態で、商品詳細ページへ遷移した動画https://gyazo.com/00c35498c4d323763f9101feded6c270
